### PR TITLE
fixed a bug where mkdir was failing due to incorrect output path

### DIFF
--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -10,8 +10,10 @@ const { getText, getURL } = require('./html');
 const input = process.argv[2];
 const output = process.argv[3];
 
-// Used to find the relative path to a file from input path.
-const re = new RegExp(`.*${input.replace(/\//g, '\\/').replace(/\./g, '\\.')}`);
+if (input === undefined || output === undefined) {
+  console.log('No files were parsed due to insufficient arguments \nPlease run the parser with the following command: npm run parse "path/to/mindmap/json/folder" "path/to/output/folder"');
+  return;
+}
 
 /*
  * Recursively walk a directory and call a function on all its files.
@@ -159,7 +161,7 @@ walkDir(input, (map, filename) => {
   parsedMap.subnodes = getSubnodes(map.nodes).map(subnode => parseSubnode(subnode));
   parsedMap.connections = map.connections.map(conn => parseConn(conn, nodesLookup));
 
-  const outputFile = path.join(output, filename.replace(re, ''));
+  const outputFile = path.join(output, filename.replace(input.replace('\\', '/'), '').replace(input.replace(/\//g, '\\'), ''));
   const outputPath = path.dirname(outputFile);
 
   // Create folder if it doesn't exist.


### PR DESCRIPTION
- fixed a bug where filename was not being replaced correctly due to a regexp issue, causing outputPath to being output+input/filename.json which caused mkdir to fail.
- added a check to inform the user of the correct usage of npm run parse command when either input or output is not specified