### PR TITLE
#40

### DIFF
--- a/sass/main.sass
+++ b/sass/main.sass
@@ -28,9 +28,11 @@ body
   padding: 15px
   text-align: center
   text-decoration: none
+  transition: background-color 0.2s ease-out
 
   &:hover
     background-color: $grey500
+    cursor: pointer
 
 .mindmap-node--editable
   cursor: all-scroll
@@ -52,7 +54,7 @@ body
 
 .mindmap-connection
   fill: transparent
-  stroke: $grey500
+  //stroke: random-color()
   stroke-dasharray: 10px 4px
   stroke-width: 3px
 
@@ -63,3 +65,4 @@ body
 
 .reddit-emoji
   border-radius: 50%
+

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -59,7 +59,7 @@ const parseNode = (node) => {
   };
 
   if (parsedNode.note) {
-    parsedNode.note = parsedNode.note.replace('if you think this can be improved in any way  please say', '');
+    parsedNode.note = parsedNode.note.replace('', 'if you think this can be improved in any way  please say');
   }
 
   const match = parsedNode.text.match(matchEmojis);
@@ -168,7 +168,7 @@ walkDir(input, (map, filename) => {
   parsedMap.connections = map.connections.map(conn => parseConn(conn, nodesLookup));
 
   // Find out the path for the output file.
-  const inputBasePath = `${path.resolve(path.join(__dirname, '../../'), input)}/`;
+  const inputBasePath = path.resolve(path.join(__dirname, '../../'), input);
   const outputFile = path.join(output, filename.replace(inputBasePath, ''));
   const outputPath = path.dirname(outputFile);
 

--- a/src/utils/nodeToHTML.js
+++ b/src/utils/nodeToHTML.js
@@ -10,9 +10,12 @@ export default (node) => {
 
   // If url is not specified remove href attribute,
   // so that the node isn't clickable.
+  
   if (!node.url) {
     href = '';
   }
 
-  return `<a ${href}>${node.text} ${categoryToIMG(node.category)}</a>`;
+  const emoji = node.category == null  && href !== '' ?  '<img class="mindmap-emoji" title="external source" src="https://assets-cdn.github.com/images/icons/emoji/unicode/1f517.png">' : categoryToIMG(node.category);
+
+  return `<a id="node-${node.index}" ${href}>${node.text} ${emoji}</a>`;
 };


### PR DESCRIPTION
- parser did not work with ``\`${}`\`` notation so I removed it, it now works for me but needs testing,
- fixed cursor not pointing on hover on nodes before/after drag of the plane,
- added anchor emoji to links that do not have a category,
- added background transition effect on hover on nodes